### PR TITLE
Makefile: use php instead of phpdbg for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C -j 1 --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C -j 1 --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C -j 1 --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C -j 1 --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

- Replace `-p phpdbg` with `-p php` in Makefile coverage target
- `phpdbg` is no longer maintained and modern PHP versions ship with built-in coverage support via pcov/Xdebug

Resolves contributte/contributte#73